### PR TITLE
Cyber: Change location of middleware log file

### DIFF
--- a/templates/application.properties.erb
+++ b/templates/application.properties.erb
@@ -28,4 +28,4 @@ poseidas.admin.username=user
 poseidas.admin.hashed.password=<%= admin_password_hash %>
 
 #logging
-logging.file=/var/log/eidas-middleware/eidas-middleware.log
+logging.file=/opt/eidas-middleware/eidas-middleware.log


### PR DESCRIPTION
- The middleware needs to write its log to a file so that the
cybersecurity monitoring solution can read it
- The middleware only has permissions to write stuff to
`/opt/eidas-middleware` within the container