### PR TITLE
EID-1159 Activate access logs for middleware

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./mw-config:/opt/eidas-middleware/configuration
       - mw-database-test:/opt/eidas-middleware/database
+    container_name: eidas-middleware
 volumes:
   mw-database-test:
     external: true

--- a/templates/application.properties.erb
+++ b/templates/application.properties.erb
@@ -28,4 +28,15 @@ poseidas.admin.username=user
 poseidas.admin.hashed.password=<%= admin_password_hash %>
 
 #logging
+##application logs
 logging.file=/opt/eidas-middleware/eidas-middleware.log
+
+##access logs
+server.tomcat.accesslog.directory=/opt/eidas-middleware
+server.tomcat.accesslog.enabled=true
+server.tomcat.accesslog.pattern=combined
+server.tomcat.accesslog.rename-on-rotate=true
+server.tomcat.accesslog.suffix=.log
+server.tomcat.accesslog.request-attributes-enabled=true
+server.tomcat.remote-ip-header=x-forwarded-for
+server.tomcat.protocol-header=x-forwarded-proto


### PR DESCRIPTION
We don't currently collect the access logs for the middleware. They
would be useful.

This updates the template for the application.properties to enable this.

There will be another PR to enable forwarding of these logs from the host to Kibana.

The log file will be rotated when the date changes.

We also defined the remote ip and protocol headers - this allows the
access logs to use the IP address specified in the X-Forwarded-For
header of the request coming from the ALB. Without it, we'd only log the
ALB's IP address. Hopefully this should be enough to get the client IP.
If not, we should be able to set some trusted IPs to ignore.