### PR TITLE
🇩🇪 EID-588 Middleware logging

### DIFF
--- a/templates/application.properties.erb
+++ b/templates/application.properties.erb
@@ -30,6 +30,8 @@ poseidas.admin.hashed.password=<%= admin_password_hash %>
 #logging
 ##application logs
 logging.file=/opt/eidas-middleware/eidas-middleware.log
+logging.level.de.governikus.eumw.eidasmiddleware=DEBUG
+logging.pattern.file=%d{ISO8601} %t %p %c - %replace{%m}{\n}{\t} %throwable{1}%n
 
 ##access logs
 server.tomcat.accesslog.directory=/opt/eidas-middleware


### PR DESCRIPTION
## Why
Middleware logs each line in Logit as a separate log entry. This produces tons of unnecessary events which should be reduced to one event. It makes debugging the middleware more difficult than it already is.

## What

* Replace newlines in message with tab
* Reduce throwable to single root cause line
* Log governikus to debug log level for now, to help get middleware upgrade working

See logback layouts http://logback.qos.ch/manual/layouts.html which I followed to get these results.

An example of a log message on multiple lines being reduced to a single line with tabs is:
````
2020-07-10T22:36:52,594 main WARN org.apache.catalina.loader.WebappClassLoaderBase - The web application [ROOT] appears to have started a thread named [Timer-0] but has failed to stop it. This is very likely to create a memory leak. Stack trace of thread:	 java.lang.Object.wait(Native Method)	 java.util.TimerThread.mainLoop(Timer.java:552)	 java.util.TimerThread.run(Timer.java:505) 
````
An example of a stack trace reduced to a single root cause line:
````
2020-07-10T22:36:52,619 main ERROR org.springframework.boot.SpringApplication - Application run failed org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'responseHandler' defined in URL [jar:file:/opt/eidas-middleware/eidas-middleware.jar!/BOOT-INF/classes!/de/governikus/eumw/eidasmiddleware/handler/ResponseHandler.class]: Unsatisfied dependency expressed through constructor parameter 2; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'serviceProviderConfig' defined in URL [jar:file:/opt/eidas-middleware/eidas-middleware.jar!/BOOT-INF/classes!/de/governikus/eumw/eidasmiddleware/ServiceProviderConfig.class]: Bean instantiation via constructor failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [de.governikus.eumw.eidasmiddleware.ServiceProviderConfig]: Constructor threw exception; nested exception is de.governikus.eumw.eidasmiddleware.BadConfigurationException: Cannot parse metadata file: connector_metadata.xml
````