### PR TITLE
BAU: Update Ruby to v2.5.8 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.7
+FROM ruby:2.5.8
 
 WORKDIR /mw-config-generator
 


### PR DESCRIPTION
This change updates Ruby to v2.5.8 in Dockerfile for consistency because the previous commit (https://github.com/alphagov/verify-eidas-mw-config-generator/commit/63ed29421c463e207879894fee8cd36d035eaaf2) bumped Ruby to v2.5.8.

Author: @adityapahuja