### PR TITLE
ensure docker build uses correct bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /mw-config-generator
 COPY Gemfile Gemfile
 COPY Gemfile.lock Gemfile.lock
 
-RUN bundle install
+RUN gem install bundler && bundler update --bundler && bundle install
 
 COPY generate generate
 COPY templates templates


### PR DESCRIPTION
bundler in the image is older than used in the lockfile so update
bundler during the docker build from rubygems